### PR TITLE
Create CMakeLists

### DIFF
--- a/CMakeLists
+++ b/CMakeLists
@@ -1,0 +1,26 @@
+# Setup the project
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+project(BuildTest)
+
+# Find Geant4 package, activate UI and vis drivers
+option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
+if(WITH_GEANT4_UIVIS)
+  find_package(Geant4 REQUIRED ui_all vis_all)
+else()
+  find_package(Geant4 REQUIRED)
+endif()
+
+# Setup G4 directories and compile definitions
+include(${Geant4_USE_FILE})
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+# Locate sources and headers
+file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
+
+# Add executable and link to G4 libraries
+add_executable(BuildTest BuildTest.cc ${sources} ${headers})
+target_link_libraries(BuildTest ${Geant4_LIBRARIES})
+
+# Install executable to 'bin' directory under CMAKE_INSTALL_PREFIX
+install(TARGETS BuildTest DESTINATION bin)


### PR DESCRIPTION
script that tells CMake how to assemble the application. there are macros required to run the sim that are usually written before and copied to the new folder that you make when you build, but as far as I can tell they're not required and we can just write them after we've tested that the build itself works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/payload-sims/4)
<!-- Reviewable:end -->
